### PR TITLE
Add Streamlit meeting transcription tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtual environment
+venv/
+.env/
+
+# Temporary files
+*.tmp
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# test1
+# Streamlit Meeting Transcription Tool
+
+This app lets you upload an MP3 or WAV file, transcribe it using OpenAI Whisper, and apply speaker diarization with **pyannote-audio**. Each speaker is displayed with a unique color and emoji for clarity. You can export the final transcript to plain text or Markdown.
+
+## Usage
+1. Install dependencies (Streamlit, openai-whisper, pyannote-audio, etc.).
+2. Set the environment variables `OPENAI_API_KEY` and `PYANNOTE_TOKEN` for access to the models.
+3. Run the app:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Upload your audio file and wait for the transcription and diarization to finish. Then download the transcript in your preferred format.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,69 @@
+import streamlit as st
+import whisper
+from pyannote.audio import Pipeline
+import os
+import tempfile
+from datetime import timedelta
+
+# Assign colors and icons
+COLORS = ["#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231", "#911eb4", "#46f0f0", "#f032e6", "#bcf60c", "#fabebe"]
+ICONS = ["😀", "😃", "😄", "😁", "😆", "😅", "😂", "🙂", "🙃", "😉"]
+
+@st.cache_resource
+def load_models():
+    whisper_model = whisper.load_model("base")
+    diarization_pipeline = Pipeline.from_pretrained(
+        "pyannote/speaker-diarization@2.1",
+        use_auth_token=os.getenv("PYANNOTE_TOKEN")
+    )
+    return whisper_model, diarization_pipeline
+
+whisper_model, diarization_pipeline = load_models()
+
+st.title("Meeting Transcription Tool")
+uploaded_file = st.file_uploader("Upload audio", type=["mp3", "wav"])
+
+if uploaded_file is not None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=uploaded_file.name) as tmp:
+        tmp.write(uploaded_file.read())
+        tmp_path = tmp.name
+
+    with st.spinner("Transcribing..."):
+        result = whisper_model.transcribe(tmp_path)
+
+    with st.spinner("Diarizing speakers..."):
+        diarization = diarization_pipeline(tmp_path)
+
+    # map speaker to color/icon
+    speaker_labels = sorted(set([label for _, label in diarization.itertracks(yield_label=True)]))
+    color_map = {spk: COLORS[i % len(COLORS)] for i, spk in enumerate(speaker_labels)}
+    icon_map = {spk: ICONS[i % len(ICONS)] for i, spk in enumerate(speaker_labels)}
+
+    transcript_txt = []
+    transcript_md = []
+
+    from pyannote.core import Segment
+    for segment in result["segments"]:
+        seg = Segment(segment['start'], segment['end'])
+        speaker = None
+        max_overlap = 0
+        for turn, _, label in diarization.itertracks(yield_label=True):
+            overlap = seg & turn
+            if overlap.duration > max_overlap:
+                speaker = label
+                max_overlap = overlap.duration
+        if speaker is None:
+            speaker = "Speaker"
+        start_time = str(timedelta(seconds=int(segment['start'])))
+        line_txt = f"[{start_time}] {speaker}: {segment['text'].strip()}"
+        line_md = f"<span style='color:{color_map[speaker]}; font-weight:bold'>{icon_map[speaker]} {speaker}</span> <span style='color:gray'>[{start_time}]</span> {segment['text'].strip()}"
+        transcript_txt.append(line_txt)
+        transcript_md.append(line_md)
+        st.markdown(line_md, unsafe_allow_html=True)
+
+    txt_content = "\n".join(transcript_txt)
+    md_content = "\n\n".join(transcript_md)
+
+    st.download_button("Download TXT", txt_content, file_name="transcript.txt")
+    st.download_button("Download MD", md_content, file_name="transcript.md")
+


### PR DESCRIPTION
## Summary
- add a Streamlit app using Whisper to transcribe uploaded audio
- apply pyannote.audio for speaker diarization
- show speakers with color blocks and icons
- allow downloads in TXT or Markdown
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c5eb5de4832185bb79cc830b6418